### PR TITLE
Fix cors, add route `users/verify`, add frontend hooks, providers, co…

### DIFF
--- a/backend/nodemon.dev.json
+++ b/backend/nodemon.dev.json
@@ -1,0 +1,12 @@
+{
+    "watch": [
+        "./src"
+    ],
+    "ext": "ts,js",
+    "ignore": [
+        "dist/*",
+        "node_modules/*",
+        "./src/routes/methods.ts"
+    ],
+    "exec": "npx tsc && node ./dist/index.js"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,8 @@
     ],
     "scripts": {
         "start": "nodemon",
-        "build": "npx tsc"
+        "build": "npx tsc",
+        "dev": "npx nodemon --config nodemon.dev.json"
     },
     "keywords": [],
     "author": "",

--- a/backend/src/controllers/users_controller.ts
+++ b/backend/src/controllers/users_controller.ts
@@ -70,5 +70,16 @@ export const UsersController = {
             // manage this error
             throw e;
         }
+    },
+    verify: async function (req) {
+        const token = req.headers.authorization?.trim().replace("Bearer ", "");
+
+        if (!token) {
+            return HttpResponse.Unauthorized()
+                .message("Could not extract token from the request headers");
+        }
+
+        const payload = jwt.verify(token, Dotenv.jwt_secret) as jwt.JwtPayload;
+        return HttpResponse.Ok().body(payload);
     }
 } as const satisfies Controller["users"];

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -29,21 +29,16 @@ for (const [key, value] of Object.entries(Dotenv)) {
 
 const app = express();
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const frontendPath = path.join(__dirname, "../../frontend/dist");
-app.use(express.static(frontendPath));
-app.get("*", (req, res) => {
-    res.sendFile(path.join(frontendPath, "index.html"));
-});
-
-app.use(cors({
-    origin: ["http://localhost:5173"],
-    // origin: [
-    //     "*"
-    // ],
+const corsOptions = {
+    origin: "http://localhost:5173",
     credentials: true,
-}));
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Content-Type", "Authorization"],
+};
+
+app.use(cors(corsOptions));
+app.options("*", cors(corsOptions));
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
@@ -55,6 +50,15 @@ app.use(cookieParser());
 app.use("/api", Middleware.schema as any);
 app.use("/api", Middleware.helpers as any, routes);
 getRouteMethods(app);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const frontendPath = path.join(__dirname, "../../frontend/dist");
+
+app.use(express.static(frontendPath));
+app.get("*", (req, res) => {
+    res.sendFile(path.join(frontendPath, "index.html"));
+});
 
 app.listen(Dotenv.port, async (e) => {
     const conn = await mongoose.connect(Dotenv.database_url);

--- a/backend/src/lib.ts
+++ b/backend/src/lib.ts
@@ -1,2 +1,4 @@
 export type { SwaggerDocs } from "./types";
 export { BACKEND_ROUTES } from "./routes/methods.js";
+export type { JwtPayload } from "jsonwebtoken";
+export type { UserPayload } from "./utils/global";

--- a/backend/src/routes/methods.ts
+++ b/backend/src/routes/methods.ts
@@ -2,6 +2,7 @@ export const BACKEND_ROUTES = {
     "users/logout": "GET",
     "users/login": "POST",
     "users/register": "POST",
+    "users/verify": "GET",
     "questions/create": "POST",
     "topics/create": "POST",
 } as const;

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -8,6 +8,7 @@ const router = Router();
 router.get("/logout", route(UsersController.logout));
 router.post("/login", route(UsersController.login));
 router.post("/register", route(UsersController.register));
+router.get("/verify", route(UsersController.verify));
 /*
  --> Add these routes to the correct router location. Here 
  --> we should have only things related to the current user

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -9,7 +9,7 @@ const R = z.object({
         .max(64, { error: "Name must be at most 64 characters long" }),
     EMAIL: z.email({ error: "Invalid email" }),
     PASSWORD: z.string().min(4).max(32).describe("Password must be a string and be defined."),
-    NOTHING: z.undefined({ error: "This route does not expect any input" }),
+    NOTHING: z.object({}),
 }).shape;
 
 export const SCHEMA = {
@@ -23,6 +23,7 @@ export const SCHEMA = {
         email: R.EMAIL,
         password: R.PASSWORD,
     }),
+    "users/verify": R.NOTHING,
     "questions/create": R.NOTHING,
     "topics/create": R.NOTHING
 } as const satisfies Record<Route, any>;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -7,6 +7,10 @@ import type { Response, Request } from "express";
 import type { ReqHelpers, ResHelpers } from "./utils/middleware.js";
 import type { HttpBuilder } from "./utils/http.js";
 
+type Is<T, U> =
+    [T] extends [U]
+    ? ([U] extends [T] ? true : false)
+    : false;
 type IsAny<T> = 0 extends (1 & T) ? true : false;
 type IsNever<T> = [T] extends [never] ? true : false;
 type IsUnknown<T> = unknown extends T
@@ -35,7 +39,7 @@ export type GetSchema<
         ? M[P][F] extends (...args: any[]) => any ? {
             method: typeof BACKEND_ROUTES[K];
             output: ReturnType<Awaited<ReturnType<M[P][F]>>["json"]>;
-            input: InputSchema[K];
+            input: Is<InputSchema[K], Record<string, never>> extends true ? undefined : InputSchema[K];
         }
         : never
         : never

--- a/backend/src/utils/http.ts
+++ b/backend/src/utils/http.ts
@@ -109,13 +109,16 @@ export function getRouteMethods(express: any) {
     } else {
         console.warn("No route registered in the app");
     }
+
+    delete routes["*"];
+
     const routesObjectEntries = Object.entries(routes)
         .map(([route, method]) => `    "${route}": "${method}",`)
         .join("\n");
     const routesTypeDef = `export const BACKEND_ROUTES = {\n${routesObjectEntries}\n} as const;\n`;
 
     const filePath = fileURLToPath(
-        new URL("../routes/methods.ts", import.meta.url)
+        new URL("../../src/routes/methods.ts", import.meta.url)
     );
     writeFileSync(filePath, routesTypeDef, "utf-8");
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "postcss": "^8.5.8",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-icons": "^5.6.0",
     "react-router-dom": "^7.13.1",
     "tailwindcss": "^4.2.1"
   },

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from "react";
-import { api } from "../utils/request";
 
 export default function Header() {
     const [name, setName] = useState("");
     const [email, setEmail] = useState("");
+
     useEffect(() => {
         setName(localStorage.getItem("full_name") || "");
         setEmail(localStorage.getItem("email") || "");
     }, []);
+
     return (
         <header>
             <p>{name}</p>

--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -1,0 +1,15 @@
+export default function Loading() {
+    return (
+        <div className="fixed top-0 left-0 w-full h-full bg-black/50 z-50 flex flex-col items-center justify-center gap-6">
+            <span className="text-2xl font-medium text-white animate-pulse">Loading</span>
+            <div
+                className="relative rounded-full w-36 aspect-square animate-spin"
+                style={{
+                    background: "conic-gradient(#ff0000, #9b00ff, #ff00aa, #ff0000)",
+                    WebkitMaskImage: "radial-gradient(circle, transparent 60%, black 0%)",
+                    maskImage: "radial-gradient(circle, transparent 60%, black 0%)",
+                }}>
+            </div>
+        </div>
+    );
+};

--- a/frontend/src/components/Notification.tsx
+++ b/frontend/src/components/Notification.tsx
@@ -1,0 +1,68 @@
+import { BiCheck, BiError, BiInfoCircle } from "react-icons/bi";
+import { MdWarning } from "react-icons/md";
+import { IoClose } from "react-icons/io5";
+import type { NotificationProps } from "../consts";
+
+type ComponentProps = NotificationProps & {
+    destroy: () => void;
+}
+
+const NotificationStandards = {
+    error: {
+        icon: <BiError className="shrink-0 h-6 w-6" />,
+        classes: `bg-red-900 text-red-200 border-red-500`,
+        defaultMsg: "Error",
+    },
+    success: {
+        icon: <BiCheck className="shrink-0 h-6 w-6" />,
+        classes: `bg-emerald-900 text-emerald-200 border-emerald-500`,
+        defaultMsg: "Success!",
+    },
+    warning: {
+        icon: <MdWarning className="shrink-0 h-6 w-6" />,
+        classes: `bg-yellow-900 text-yellow-200 border-yellow-500`,
+        defaultMsg: "Warning!",
+    },
+    info: {
+        icon: <BiInfoCircle className="shrink-0 h-6 w-6" />,
+        classes: `bg-blue-900 text-blue-200 border-blue-500`,
+        defaultMsg: "No changes made",
+    },
+} as const;
+
+export const NotificationTopCenter = ({ notifications }: { notifications: ComponentProps[] }) => {
+    const iterator = notifications.filter((n, index, self) => {
+        if (n.msg === undefined) return true;
+        return self.findIndex(m => m.msg === n.msg) === index;
+    });
+
+    return (
+        <div className="fixed top-4 left-1/2 transform -translate-x-1/4 z-50 flex flex-col gap-4">
+            {iterator.map((obj, index) => {
+                const { icon, classes, defaultMsg } = obj
+                    ? NotificationStandards[obj.type]
+                    : { icon: "", classes: "", defaultMsg: "" };
+                return (
+                    <div
+                        key={index}
+                        role="alert"
+                        className={`flex gap-4
+                    items-center px-5 py-3.5 max-w-full rounded-lg transition-all duration-300 ease-in-out transform
+                    border-l-8 ${classes} 
+                    ${obj.isVisible && !obj.isFading ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-4 scale-95"}`}
+                    >
+                        {icon}
+                        <span className="font-semibold">{obj?.msg || defaultMsg}</span>
+                        <button
+                            type="button"
+                            onClick={() => obj.destroy()}
+                            aria-label="Close notification"
+                            className="ml-auto text-lg">
+                            <IoClose className="h-5 w-5 text-inherit" />
+                        </button>
+                    </div>
+                );
+            })}
+        </div>
+    )
+};

--- a/frontend/src/consts.ts
+++ b/frontend/src/consts.ts
@@ -1,0 +1,14 @@
+
+export const DEFAULT_NOTIFICATION_TIMEOUT = 5000;
+export const MAX_NOTIFICATIONS = 7;
+
+export interface NotificationProps {
+    persist?: boolean,
+    msg?: string,
+    type: "success" | "error" | "warning" | "info",
+    vanishTimeout?: number,
+    isFading?: boolean,
+    isVisible?: boolean
+};
+export type NotificationFn = (obj: NotificationProps) => void;
+export type SetState<T = any> = React.Dispatch<React.SetStateAction<T>>;

--- a/frontend/src/hooks.ts
+++ b/frontend/src/hooks.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Hook que dispara um callback quando um clique ocorre fora do elemento referenciado.
+ * @param callback Função a ser chamada quando o clique for fora dos elementos protegidos.
+ * @param exceptions Refs que não devem disparar o evento.
+ * @returns Ref principal para ser atribuído ao elemento principal.
+ */
+export function useClickOut<T extends HTMLElement = any>(
+    callback: () => void,
+    exceptions: React.RefObject<HTMLElement>[] = []
+) {
+    const ref = useRef<T | null>(null);
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            const target = event.target as Node;
+            if (
+                ref.current &&
+                !ref.current.contains(target) &&
+                !exceptions.some((exception) => exception.current?.contains(target))
+            ) {
+                callback();
+            }
+        };
+
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [callback, exceptions]);
+
+    return ref;
+};
+
+export function useDebounce<T>(value: T, delay: number): T {
+    const [debounced, setDebounced] = useState(value);
+
+    useEffect(() => {
+        const handler = setTimeout(() => setDebounced(value), delay);
+        return () => clearTimeout(handler);
+    }, [value, delay]);
+
+    return debounced;
+}
+
+/**
+ * Skips first component render 
+ */
+export function useSkip(fn: () => void, deps: any[] = []) {
+    const isMounted = useRef(false);
+    useEffect(() => {
+        if (!isMounted.current) {
+            isMounted.current = true;
+            return;
+        }
+        fn();
+    }, deps);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,13 +4,19 @@ import "./index.css"
 import Homepage from "./pages/Homepage.tsx"
 import Login from "./pages/Login.tsx"
 import Register from "./pages/Register.tsx";
+import AppProvider from "./providers/AppProvider.tsx";
+import RequireLogin from "./providers/RequireLogin.tsx";
 
 createRoot(document.getElementById("root")!).render(
     <BrowserRouter>
-        <Routes>
-            <Route path="/" element={<Homepage />} />
-            <Route path="/login" element={<Login />} />
-            <Route path="/register" element={<Register />} />
-        </Routes>
+        <AppProvider>
+            <Routes>
+                <Route element={<RequireLogin />}>
+                    <Route path="/" element={<Homepage />} />
+                </Route>
+                <Route path="/login" element={<Login />} />
+                <Route path="/register" element={<Register />} />
+            </Routes>
+        </AppProvider>
     </BrowserRouter>
 )

--- a/frontend/src/pages/Homepage.tsx
+++ b/frontend/src/pages/Homepage.tsx
@@ -1,8 +1,10 @@
+import Header from "../components/Header";
+
 export default function Homepage() {
-    
+
     return (
-        <div>
-            
-        </div>
+        <>
+            <Header />
+        </>
     )
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,28 +3,40 @@ import Button from "../components/Button";
 import { Field } from "../components/Form";
 import { api } from "../utils/request";
 import { useNavigate } from "react-router-dom";
+import { useNotification } from "../providers/NotificationProvider";
 
 export default function Login() {
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [ErrorText, setErrorText] = useState("");
     const navigate = useNavigate();
+    const { addNotification } = useNotification();
 
     const loginRequest = async () => {
-        const response = await api("users/login", { email, password })
-        if (response.ok && response.body != undefined) {
-            const token = response.body.token;
-            localStorage.setItem("token", token);
-            localStorage.setItem("full_name", response.body.full_name);
-            localStorage.setItem("email", response.body.email);
-            navigate("/");
+        try {
+            const response = await api("users/login", { email, password })
+            if (response.ok && response.body != undefined) {
+                const token = response.body.token;
+                localStorage.setItem("token", token);
+                localStorage.setItem("full_name", response.body.full_name);
+                localStorage.setItem("email", response.body.email);
+                return navigate("/");
+            } else {
+                setErrorText(response.message);
+                throw new Error(response.message);
+            }
+        } catch (e) {
+            addNotification({
+                type: "error",
+                msg: e instanceof Error ? e.message : String(e),
+                persist: true
+            });
         }
-        setErrorText(response.message);
     }
 
     return (
         <div className="
-            place-self-center my-12 rounded-xl max-w-md
+            place-self-center my-20 rounded-xl max-w-md
             w-full flex flex-col gap-4 p-6 bg-zinc-800 
             text-white
         ">

--- a/frontend/src/providers/AppProvider.tsx
+++ b/frontend/src/providers/AppProvider.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import { UserProvider } from "./UserProvider";
+import { NotificationProvider } from "./NotificationProvider";
+
+const Providers = [
+    UserProvider,
+    NotificationProvider
+];
+
+const AppProvider = ({ children }: { children: ReactNode }) => {
+    return Providers.reduce(
+        (acc, Provider) => <Provider>{acc}</Provider>,
+        children
+    );
+};
+
+export default AppProvider;

--- a/frontend/src/providers/NotificationProvider.tsx
+++ b/frontend/src/providers/NotificationProvider.tsx
@@ -1,0 +1,88 @@
+import { createContext, useContext, useState, type ReactNode, type ComponentType } from "react";
+import { useNavigate } from "react-router-dom";
+import { DEFAULT_NOTIFICATION_TIMEOUT, MAX_NOTIFICATIONS, type NotificationProps } from "../consts";
+import { useSkip } from "../hooks";
+import { NotificationTopCenter } from "../components/Notification";
+
+type ComponentProps = NotificationProps & {
+    id: string;
+    destroy: () => void;
+};
+
+type ComponentPrototype = ComponentType<{ notifications: ComponentProps[] }>;
+
+type NotificationContextType = {
+    notifications: ComponentProps[];
+    addNotification: (notify: NotificationProps, Component?: ComponentPrototype) => void;
+}
+const NotificationContext = createContext<NotificationContextType | undefined>(undefined);
+
+export const NotificationProvider = ({ children }: { children: ReactNode }) => {
+    const [notifications, setNotifications] = useState<ComponentProps[]>([]);
+    const [NotificationComponent, setNotificationComponent] = useState<ComponentPrototype | null>(() => NotificationTopCenter);
+    const navigate = useNavigate();
+
+    useSkip(() => {
+        notifications.forEach(e => {
+            if (!e.persist) {
+                e.destroy();
+            }
+        });
+    }, [navigate])
+
+    const addNotification = (notify: NotificationProps, Component?: ComponentPrototype) => {
+        const id = Date.now().toString();
+        const fadeOut = () => {
+            setNotifications((prev) =>
+                prev.map((n) => (n.id === id ? { ...n, isFading: true } : n))
+            );
+            const removeTimeout = setTimeout(() => {
+                setNotifications((prev) => prev.filter((n) => n.id !== id));
+            }, 300);
+            return () => clearTimeout(removeTimeout);
+        };
+        const newNotification: ComponentProps = {
+            ...notify,
+            id,
+            destroy: fadeOut,
+            isFading: false,
+            isVisible: false,
+        };
+        setNotifications((prev) => {
+            if (prev.length >= MAX_NOTIFICATIONS) prev.shift();
+            return [...prev, newNotification];
+        });
+        const showTimeout = setTimeout(() => {
+            setNotifications((prev) =>
+                prev.map((n) => (n.id === id ? { ...n, isVisible: true } : n))
+            );
+        }, 50);
+        if (Component) {
+            setNotificationComponent(() => Component);
+        }
+        let hideTimeout: number | NodeJS.Timeout;
+        if (!(notify.vanishTimeout && notify.vanishTimeout === Infinity)) {
+            hideTimeout = setTimeout(fadeOut, notify.vanishTimeout || DEFAULT_NOTIFICATION_TIMEOUT);
+            return () => {
+                clearTimeout(showTimeout);
+                clearTimeout(hideTimeout);
+            };
+        }
+        return () => clearTimeout(showTimeout);
+    };
+
+    return (
+        <NotificationContext.Provider value={{ notifications, addNotification }}>
+            {children}
+            {NotificationComponent && <NotificationComponent notifications={notifications} />}
+        </NotificationContext.Provider>
+    );
+};
+
+export const useNotification = () => {
+    const context = useContext(NotificationContext);
+    if (!context) {
+        throw new Error("useNotification deve ser usado dentro de um NotificationProvider");
+    }
+    return context;
+};

--- a/frontend/src/providers/RequireLogin.tsx
+++ b/frontend/src/providers/RequireLogin.tsx
@@ -1,0 +1,60 @@
+import { Navigate, Outlet } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import Loading from '../components/Loading';
+import { useUser } from '../providers/UserProvider';
+import { useNotification } from '../providers/NotificationProvider';
+import { api } from '../utils/request';
+
+const fetchData = async () => {
+    const token = localStorage.getItem("token");
+
+    if (!token) {
+        throw new Error("Authentication Token not found. You must log in again");
+    }
+
+    return await api("users/verify");
+}
+
+const RequireLogin = () => {
+    const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
+    const { user, setUser } = useUser();
+    const { addNotification } = useNotification();
+
+    useEffect(() => {
+        const checkAuth = async () => {
+            try {
+                const response = await fetchData();
+
+                console.log(response);
+
+                if (!response.ok && response.message) {
+                    throw new Error(response.message);
+                }
+
+                setUser(response.body!);
+                setIsAuthenticated(true);
+            } catch (e) {
+                addNotification({
+                    type: "error",
+                    msg: `Error verifying authentication: ${e instanceof Error ? e.message : String(e)}`,
+                    persist: true
+                });
+                setIsAuthenticated(false);
+            }
+        };
+        if (!user) {
+            checkAuth();
+        }
+        else {
+            setIsAuthenticated(true);
+        }
+    }, [user])
+
+    if (isAuthenticated === null) {
+        return <Loading />;
+    }
+
+    return isAuthenticated ? <Outlet /> : <Navigate to="/login" replace />;
+}
+
+export default RequireLogin;

--- a/frontend/src/providers/UserProvider.tsx
+++ b/frontend/src/providers/UserProvider.tsx
@@ -1,0 +1,49 @@
+import type { JwtPayload, UserPayload } from "backend";
+import { createContext, useState, useContext, type ReactNode, useEffect } from "react";
+import type { SetState } from "../consts";
+
+type UserContextType = {
+    user: JwtPayload | null;
+    setUser: SetState<UserPayload | null>;
+    isAuthenticated: boolean;
+    logout: () => void;
+};
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const UserProvider = ({ children }: { children: ReactNode }) => {
+    const [user, setUser] = useState<UserContextType["user"] | null>(() => {
+        const storedUser = localStorage.getItem("user");
+        return storedUser ? JSON.parse(storedUser) : null;
+    });
+    const isAuthenticated = Boolean(user);
+
+    useEffect(() => {
+        if (user) {
+            localStorage.setItem("user", JSON.stringify(user));
+        } else {
+            localStorage.removeItem("user");
+        }
+    }, [user]);
+
+    /** Logout local apenas, eliminando o "user", e removendo o token */
+    const logout = () => {
+        setUser(null);
+        localStorage.removeItem("token");
+        localStorage.removeItem("user");
+    };
+
+    return (
+        <UserContext.Provider value={{ user, setUser, isAuthenticated, logout }}>
+            {children ?? null}
+        </UserContext.Provider>
+    );
+};
+
+export const useUser = () => {
+    const context = useContext(UserContext);
+    if (!context) {
+        throw new Error("useUser must be used within a UserProvider");
+    }
+    return context;
+};

--- a/frontend/src/utils/request.ts
+++ b/frontend/src/utils/request.ts
@@ -17,10 +17,16 @@ export async function api<
             credentials: "include"
         };
 
-        const body = input[0];
+        const token = localStorage.getItem("token");
+        if (token) {
+            args.headers = {
+                ...args.headers,
+                Authorization: `Bearer ${token}`,
+            };
+        }
 
-        if (body && method !== "GET") {
-            args.body = JSON.stringify(body);
+        if (method !== "GET") {
+            args.body = JSON.stringify(input[0]);
         }
 
         const request = await fetch(`${URL}/${path}`, args);


### PR DESCRIPTION
- Added `nodemon.dev.json` that is meant to be used if you're running the project locally - the other one will be used to deploy our app
- Fix cors issues when sending header `Authorization`
- Fix route inference and automatic generation of `methods.ts` file when a new route is registered
- Fix input schema rejecting `{}` when express coerces undefined to object when the request has method `GET` (No longer gets error: "This route does not expect any input")
- Added several component providers to frontend
    - Added notification and loading component
    - Added user hook that can be used inside routes that expect the user to be authenticated to use, using its methods can recover its session data
    - Added `useSkip` hook to prevent the first renderization to trigger double-requests
    - Added `useClickOut` hook that takes a reference of a DOM object and hides it when the user clicks outside of its box area
- Added `consts.ts` file that will hold things that should be known at compile time
- Added lib `react-icons`