### PR TITLE
Authentication middleware and new structure added to `/methods.ts`

### DIFF
--- a/backend/src/controllers/users_controller.ts
+++ b/backend/src/controllers/users_controller.ts
@@ -26,7 +26,7 @@ export const UsersController = {
         return HttpResponse.Ok().message("User logged in successfully").body({ token, ...payload });
     },
     logout: async function (req, res) {
-        const token = req.headers.authorization?.trim().replace("Bearer ", "");
+        const token = req.jwt();
 
         if (!token) {
             console.warn("Non-authenticated user is trying to logout");
@@ -72,14 +72,6 @@ export const UsersController = {
         }
     },
     verify: async function (req) {
-        const token = req.headers.authorization?.trim().replace("Bearer ", "");
-
-        if (!token) {
-            return HttpResponse.Unauthorized()
-                .message("Could not extract token from the request headers");
-        }
-
-        const payload = jwt.verify(token, Dotenv.jwt_secret) as jwt.JwtPayload;
-        return HttpResponse.Ok().body(payload);
+        return HttpResponse.Ok().body(req.payload);
     }
 } as const satisfies Controller["users"];

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -47,17 +47,17 @@ app.use(cookieParser());
  * I guarantee that the following middlewares will always work, so we cast
  * them to `any`
  */
-app.use("/api", Middleware.schema as any);
+app.use("/api", Middleware.schema);
 app.use("/api", Middleware.helpers as any, routes);
 getRouteMethods(app);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const frontendPath = path.join(__dirname, "../../frontend/dist");
+const frontend = path.join(__dirname, "../../frontend/dist");
 
-app.use(express.static(frontendPath));
-app.get("*", (req, res) => {
-    res.sendFile(path.join(frontendPath, "index.html"));
+app.use(express.static(frontend));
+app.get("*", (_, res) => {
+    res.sendFile(path.join(frontend, "index.html"));
 });
 
 app.listen(Dotenv.port, async (e) => {

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -2,14 +2,14 @@ import users from "./users.js";
 import questions from "./questions.js";
 import topics from "./topics.js";
 import { NextFunction, Router } from "express";
-import { ControllerFn } from "../types.js";
-import { HttpResponse } from "../utils/http.js";
+import { HttpBuilder, HttpResponse } from "../utils/http.js";
+import { Middleware } from "../utils/middleware.js";
 
 const router = Router();
 
 router.use("/users", users);
-router.use("/questions", questions);
-router.use("/topics", topics);
+router.use("/questions", Middleware.authentication, questions);
+router.use("/topics", Middleware.authentication, topics);
 
 /**
  * Used to unsafely cast the type of the functions defined within the controller object
@@ -17,11 +17,13 @@ router.use("/topics", topics);
  * controllers will be the last middleware in the chain. They're being used to define
  * the req.body input type, nothing else
  */
-export function route(f: ControllerFn<any>) {
+
+export function route(f: (req: any, res: any) => Promise<HttpBuilder<any, any>>) {
     const name = f.name;
     console.log(name);
     return async (req: any, res: any, next: NextFunction) => {
         try {
+            console.log(`Calling controller ${name}`);
             let data = await f(req, res);
             console.log(`Controller ${name} returned: `, data);
 

--- a/backend/src/routes/methods.ts
+++ b/backend/src/routes/methods.ts
@@ -6,3 +6,9 @@ export const BACKEND_ROUTES = {
     "questions/create": "POST",
     "topics/create": "POST",
 } as const;
+
+export const BACKEND_PROTECTED_ROUTES = [
+	"users/verify",
+	"questions/create",
+	"topics/create"
+] as const;

--- a/backend/src/routes/questions.ts
+++ b/backend/src/routes/questions.ts
@@ -1,7 +1,6 @@
 import { QuestionsController } from "../controllers/questions_controller.js";
 import { Router } from "express";
 import { route } from "./index.js";
-import { Middleware } from "../utils/middleware.js";
 
 const router = Router();
 

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -8,7 +8,11 @@ const router = Router();
 router.get("/logout", route(UsersController.logout));
 router.post("/login", route(UsersController.login));
 router.post("/register", route(UsersController.register));
-router.get("/verify", route(UsersController.verify));
+router.get(
+    "/verify",
+    Middleware.authentication,
+    route(UsersController.verify)
+);
 /*
  --> Add these routes to the correct router location. Here 
  --> we should have only things related to the current user

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1,11 +1,12 @@
 import type { UsersController } from "./controllers/users_controller.js";
 import type { InputSchema } from "./schema.js";
-import type { BACKEND_ROUTES } from "./routes/methods.js";
+import type { BACKEND_PROTECTED_ROUTES, BACKEND_ROUTES } from "./routes/methods.js";
 import type { QuestionsController } from "./controllers/questions_controller.js";
 import type { TopicsController } from "./controllers/topics_controller.js";
 import type { Response, Request } from "express";
 import type { ReqHelpers, ResHelpers } from "./utils/middleware.js";
 import type { HttpBuilder } from "./utils/http.js";
+import { JwtPayload } from "jsonwebtoken";
 
 type Is<T, U> =
     [T] extends [U]
@@ -40,6 +41,7 @@ export type GetSchema<
             method: typeof BACKEND_ROUTES[K];
             output: ReturnType<Awaited<ReturnType<M[P][F]>>["json"]>;
             input: Is<InputSchema[K], Record<string, never>> extends true ? undefined : InputSchema[K];
+            protected: K extends typeof BACKEND_PROTECTED_ROUTES[number] ? true : false
         }
         : never
         : never
@@ -54,7 +56,13 @@ export type Controllers = {
 };
 
 export type ControllerFn<R extends keyof InputSchema> = (
-    req: Omit<Request, "body"> & { body: InputSchema[R] } & ReqHelpers,
+    req: Omit<Request, "body">
+        & { body: InputSchema[R] }
+        & ReqHelpers
+        & (R extends typeof BACKEND_PROTECTED_ROUTES[number] ? {
+            token: string,
+            payload: JwtPayload
+        } : {}),
     res: Response & ResHelpers
 ) => Promise<HttpBuilder<any, any>>
 

--- a/backend/src/utils/http.ts
+++ b/backend/src/utils/http.ts
@@ -44,7 +44,7 @@ class HttpResponseBuilder<
     }
 
     public send(res: Response) {
-        res.status(this._status).json(this.json());
+        return res.status(this._status).json(this.json());
     }
 
     public json() {
@@ -82,24 +82,85 @@ export const HttpResponse = (() => {
 
 export function getRouteMethods(express: any) {
     const routes = {} as Record<string, string>;
+    const protectedRoutes = new Set<string>();
 
-    function extractRoutes(stack: any[], basePath = "") {
-        stack.forEach((middleware) => {
-            if (middleware.route) {
-                const methods = Object.keys(middleware.route.methods)
-                    .map(m => m.toUpperCase())
-                    .join(', ');
-                let cleanPath = basePath.replace(/^\/api\//, '') + middleware.route.path;
-                cleanPath = cleanPath.replace(/\/:[^/]+/g, '');
-                cleanPath = cleanPath.replace(/\/$/, '');
+    function normalizePath(path: string) {
+        if (!path) return "";
+        let result = path.replace(/\/+/g, "/");
+        result = result.replace(/^\/api\//, "");
+        result = result.replace(/\/:[^/]+/g, "");
+        result = result.replace(/\/$/, "");
+        return result;
+    }
+
+    function getLayerMountPath(layer: any) {
+        const source = layer?.regexp?.source;
+        if (!source) return "";
+
+        if (source === "^\\/?(?=\\/|$)") {
+            return "";
+        }
+
+        return source
+            .replace("^\\", "")
+            .replace("\\/?(?=\\/|$)", "")
+            .replace(/\\\//g, "/");
+    }
+
+    function isAuthenticationLayer(layer: any) {
+        return layer?.name === "authentication";
+    }
+
+    function extractRoutes(
+        stack: any[],
+        basePath = "",
+        inheritedProtected = false
+    ) {
+        let stackProtected = inheritedProtected;
+        const protectedMounts = new Set<string>();
+
+        for (const layer of stack) {
+            const mountFragment = getLayerMountPath(layer);
+            const mountPath = normalizePath(basePath + mountFragment);
+
+            if (layer.route) {
+                const methods = Object.keys(layer.route.methods)
+                    .map((m) => m.toUpperCase())
+                    .join(", ");
+
+                const cleanPath = normalizePath(basePath + layer.route.path);
+
                 routes[cleanPath] = methods;
-            } else if (middleware.name === "router" && middleware.handle.stack) {
-                extractRoutes(
-                    middleware.handle.stack,
-                    basePath + (middleware.regexp.source.replace("^\\", "").replace("\\/?(?=\\/|$)", "") || '')
-                );
+
+                const routeProtected =
+                    stackProtected ||
+                    layer.route.stack.some((routeLayer: any) =>
+                        isAuthenticationLayer(routeLayer)
+                    );
+
+                if (routeProtected) {
+                    protectedRoutes.add(cleanPath);
+                }
+
+                continue;
             }
-        });
+
+            if (isAuthenticationLayer(layer)) {
+                if (mountPath === normalizePath(basePath)) {
+                    stackProtected = true;
+                } else {
+                    protectedMounts.add(mountPath);
+                }
+                continue;
+            }
+
+            if (layer.name === "router" && layer.handle?.stack) {
+                const nestedProtected =
+                    stackProtected || protectedMounts.has(mountPath);
+
+                extractRoutes(layer.handle.stack, mountPath, nestedProtected);
+            }
+        }
     }
 
     const router = express._router;
@@ -115,10 +176,22 @@ export function getRouteMethods(express: any) {
     const routesObjectEntries = Object.entries(routes)
         .map(([route, method]) => `    "${route}": "${method}",`)
         .join("\n");
-    const routesTypeDef = `export const BACKEND_ROUTES = {\n${routesObjectEntries}\n} as const;\n`;
+
+    const routesTypeDef =
+        `export const BACKEND_ROUTES = {\n${routesObjectEntries}\n} as const;\n`;
+
+    const protectedRoutesDef = [...protectedRoutes]
+        .map((route) => `"${route}"`)
+        .join(",\n\t");
+
+    const protectedRoutesTypeDef =
+        `\nexport const BACKEND_PROTECTED_ROUTES = [\n\t${protectedRoutesDef}\n] as const;\n`;
+
+    const result = routesTypeDef + protectedRoutesTypeDef;
 
     const filePath = fileURLToPath(
         new URL("../../src/routes/methods.ts", import.meta.url)
     );
-    writeFileSync(filePath, routesTypeDef, "utf-8");
+
+    writeFileSync(filePath, result, "utf-8");
 }

--- a/backend/src/utils/middleware.ts
+++ b/backend/src/utils/middleware.ts
@@ -2,11 +2,15 @@ import type { NextFunction, Request, Response } from "express";
 import { BACKEND_ROUTES } from "../routes/methods.js";
 import { SCHEMA } from "../schema.js";
 import { HttpResponse } from "./http.js";
+import { Dotenv } from "../index.js";
+import jwt from "jsonwebtoken";
 
 /**
  * Helper functions to use on `req` object as method
  */
-export interface ReqHelpers { }
+export interface ReqHelpers {
+    jwt: () => string | undefined
+}
 
 /**
  * Helper functions to use on `res` object as method
@@ -15,7 +19,29 @@ export interface ResHelpers { }
 
 export const Middleware = {
     helpers: async (req: Request & ReqHelpers, res: Response & ResHelpers, next: NextFunction) => {
-        next()
+        req.jwt = () => req.headers.authorization?.trim().replace("Bearer ", "");
+
+        next();
+    },
+    authentication: async (req: Request, res: Response, next: NextFunction) => {
+        const token = (req as any).jwt();
+
+        if (!token) {
+            return HttpResponse.Unauthorized()
+                .message("Could not extract token from the request headers")
+                .send(res);
+        }
+
+        try {
+            const payload = jwt.verify(token, Dotenv.jwt_secret) as jwt.JwtPayload;
+            (req as any).token = token;
+            (req as any).payload = payload;
+            next();
+        } catch (e: any) {
+            return HttpResponse.Unauthorized()
+                .message(e?.message || "Failed to verify token signature")
+                .send(res);
+        }
     },
     /**
      * Dynamically checks which route was called and verifies if `req.body` is valid


### PR DESCRIPTION
- Created authentication middleware
- Added fields `req.token` and `req.payload`, available only if the route at some point the authentication middleware is present in this route's stack
- Added method `req.jwt()` that returns `string | undefined`, which represents the JWT token provided in the request headers. This method is available in every controller, regardless of if it needs authentication or not
- `methods.ts` now has `BACKEND_PROTECTED_ROUTES` array which defines those routes that require the header `Authentication: Bearer ${token}`
- All routes under the prefix `/questions` and `/topics` require authentication