### PR TITLE
Demo quiz app

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,49 @@
+# EduCMS Demo
+
+This folder contains a separate demo app for presentation use. It does not live inside the main frontend and it does not own any database state. Instead:
+
+- `demo/backend` logs into the CMS with dedicated demo credentials
+- `demo/backend` fetches questions and topics from the CMS
+- `demo/backend` strips answer keys before sending quiz data to the browser
+- `demo/frontend` renders the quiz and submits answers back to `demo/backend`
+
+## Run It
+
+### 1. Start the main CMS backend
+
+Make sure the project backend is running on `http://localhost:3000`.
+
+### 2. Build the demo frontend
+
+```bash
+cd demo/frontend
+npm install
+npm run build
+```
+
+### 3. Start the demo backend
+
+```bash
+cd demo/backend
+cp .env.example .env
+npm install
+npm run dev
+```
+
+Set `CMS_EMAIL` and `CMS_PASSWORD` in `demo/backend/.env` to a CMS account that owns the quiz content you want to present.
+The demo backend uses `PORT` and defaults to `3001`.
+
+### 4. Open the demo
+
+Visit `http://localhost:3001`.
+
+## Optional Frontend Dev Mode
+
+If you want hot reloading while editing the demo UI, you can still run:
+
+```bash
+cd demo/frontend
+npm run dev
+```
+
+That uses the existing Vite setup and talks to the demo backend from `http://localhost:4173`.

--- a/demo/backend/.env.example
+++ b/demo/backend/.env.example
@@ -1,0 +1,5 @@
+PORT=3001
+FRONTEND_ORIGIN=http://localhost:4173
+CMS_BASE_URL=http://localhost:3000
+CMS_EMAIL=demo@example.com
+CMS_PASSWORD=demo-password

--- a/demo/backend/package.json
+++ b/demo/backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "educms-demo-backend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "seed": "tsx src/seed.ts"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^17.3.1",
+    "express": "^5.1.0"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.4",
+    "@types/node": "^24.10.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/demo/backend/src/cms.ts
+++ b/demo/backend/src/cms.ts
@@ -1,0 +1,99 @@
+import type { CmsQuestion, CmsResponse, CmsTopic } from "./types.js";
+
+let cachedToken: string | null = null;
+
+function getConfig() {
+    const baseUrl = (process.env.CMS_BASE_URL || "http://localhost:3000").replace(/\/+$/, "");
+    const email = process.env.CMS_EMAIL;
+    const password = process.env.CMS_PASSWORD;
+
+    if (!email || !password) {
+        throw new Error("CMS_EMAIL and CMS_PASSWORD must be configured for the demo backend");
+    }
+
+    return { baseUrl, email, password };
+}
+
+async function cmsFetch<T>(
+    path: string,
+    init: RequestInit,
+    includeAuth = true,
+    allowRetry = true
+) {
+    const { baseUrl } = getConfig();
+    const headers = new Headers(init.headers);
+    headers.set("Content-Type", "application/json");
+
+    if (includeAuth) {
+        const token = await getCmsToken();
+        headers.set("Authorization", `Bearer ${token}`);
+    }
+
+    const response = await fetch(`${baseUrl}/api/${path}`, {
+        ...init,
+        headers
+    });
+
+    const json = await response.json() as CmsResponse<T>;
+
+    if (response.status === 401 && includeAuth && allowRetry) {
+        cachedToken = null;
+        return cmsFetch<T>(path, init, includeAuth, false);
+    }
+
+    if (!json.ok) {
+        throw new Error(json.message || `CMS request failed for ${path}`);
+    }
+
+    return json.body as T;
+}
+
+export async function getCmsToken() {
+    if (cachedToken) {
+        return cachedToken;
+    }
+
+    const { baseUrl, email, password } = getConfig();
+
+    const response = await fetch(`${baseUrl}/api/users/login`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+            email,
+            password
+        })
+    });
+
+    const json = await response.json() as CmsResponse<{ token: string }>;
+
+    if (!json.ok || !json.body?.token) {
+        throw new Error(json.message || "Failed to log into the CMS demo account");
+    }
+
+    cachedToken = json.body.token;
+    return cachedToken;
+}
+
+export async function getTopics() {
+    return cmsFetch<CmsTopic[]>("topics/all", {
+        method: "GET"
+    });
+}
+
+export async function getQuestions() {
+    return cmsFetch<CmsQuestion[]>("questions/all", {
+        method: "POST",
+        body: JSON.stringify({})
+    });
+}
+
+export async function getQuestion(questionId: string) {
+    return cmsFetch<CmsQuestion>("questions/get", {
+        method: "POST",
+        body: JSON.stringify({
+            question_id: questionId
+        })
+    });
+}

--- a/demo/backend/src/index.ts
+++ b/demo/backend/src/index.ts
@@ -1,0 +1,104 @@
+import cors from "cors";
+import dotenv from "dotenv";
+import express from "express";
+import { existsSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { getQuestion, getQuestions, getTopics } from "./cms.js";
+import { evaluateAnswer, sanitizeQuiz } from "./quiz.js";
+import type { CheckAnswerInput } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.join(__dirname, "../.env") });
+
+const app = express();
+const port = Number(process.env.PORT || 3001);
+const frontendOrigin = process.env.FRONTEND_ORIGIN || "http://localhost:4173";
+
+app.use(cors({
+    origin: frontendOrigin,
+    credentials: false
+}));
+
+app.use(express.json());
+
+app.get("/api/health", (_req, res) => {
+    res.json({
+        ok: true
+    });
+});
+
+app.get("/api/quiz", async (_req, res) => {
+    try {
+        const [topics, questions] = await Promise.all([
+            getTopics(),
+            getQuestions()
+        ]);
+
+        res.json({
+            ok: true,
+            body: sanitizeQuiz(topics, questions)
+        });
+    } catch (error) {
+        res.status(500).json({
+            ok: false,
+            message: error instanceof Error ? error.message : String(error)
+        });
+    }
+});
+
+app.post("/api/check", async (req, res) => {
+    const body = req.body as Partial<CheckAnswerInput>;
+
+    if (!body.questionId || body.answer === undefined) {
+        return res.status(400).json({
+            ok: false,
+            message: "questionId and answer are required"
+        });
+    }
+
+    if (typeof body.answer !== "string" && !Array.isArray(body.answer)) {
+        return res.status(400).json({
+            ok: false,
+            message: "answer must be a string or an array of strings"
+        });
+    }
+
+    try {
+        const question = await getQuestion(body.questionId);
+        const result = evaluateAnswer(question, body.answer);
+
+        return res.json({
+            ok: true,
+            body: result
+        });
+    } catch (error) {
+        return res.status(500).json({
+            ok: false,
+            message: error instanceof Error ? error.message : String(error)
+        });
+    }
+});
+
+const frontendDist = path.join(__dirname, "../../frontend/dist");
+const frontendIndex = path.join(frontendDist, "index.html");
+
+if (existsSync(frontendIndex)) {
+    app.use(express.static(frontendDist));
+    app.use((_req, res) => {
+        res.sendFile(frontendIndex);
+    });
+} else {
+    app.use((_req, res) => {
+        res.status(503).json({
+            ok: false,
+            message: "Demo frontend has not been built yet. Run `npm run build` in demo/frontend."
+        });
+    });
+}
+
+app.listen(port, () => {
+    console.log(`EduCMS demo backend listening on ${port}`);
+});

--- a/demo/backend/src/quiz.ts
+++ b/demo/backend/src/quiz.ts
@@ -1,0 +1,166 @@
+import type {
+    CheckAnswerResult,
+    CmsQuestion,
+    CmsTopic,
+    DemoQuestion,
+    DemoQuizPayload
+} from "./types.js";
+
+function normalizeText(value: string) {
+    return value.trim().toLowerCase();
+}
+
+function topicIdOf(topic: CmsTopic) {
+    return String(topic._id);
+}
+
+function questionIdOf(question: CmsQuestion) {
+    return String(question.question_id || question._id);
+}
+
+function answerModeOf(question: CmsQuestion): DemoQuestion["answerMode"] {
+    if (question.type === "TF") {
+        return "boolean";
+    }
+
+    if (question.type === "FRQ") {
+        return question.frq?.kind === "NUMBER" ? "number" : "text";
+    }
+
+    return question.choice?.answers?.multiple ? "multiple" : "single";
+}
+
+function optionsOf(question: CmsQuestion) {
+    if (question.type === "TF") {
+        return ["True", "False"];
+    }
+
+    return question.choice?.options ?? [];
+}
+
+function formatCorrectAnswer(question: CmsQuestion) {
+    if (question.type === "MCQ") {
+        if (question.choice?.answers?.single) {
+            return question.choice.answers.single;
+        }
+
+        if (question.choice?.answers?.multiple?.length) {
+            return question.choice.answers.multiple.join(", ");
+        }
+    }
+
+    if (question.type === "TF") {
+        return question.choice?.answers?.single ?? "Unknown";
+    }
+
+    if (question.frq?.kind === "NUMBER") {
+        const numbers = question.frq.accepted_numbers ?? [];
+        const tolerance = question.frq.tolerance ?? 0;
+        const joined = numbers.join(" or ");
+        return tolerance > 0 ? `${joined} (tolerance ±${tolerance})` : joined;
+    }
+
+    if (question.frq?.kind === "TEXT") {
+        return (question.frq.accepted_texts ?? []).join(" / ");
+    }
+
+    return "Unknown";
+}
+
+function isCorrect(question: CmsQuestion, answer: string | string[]) {
+    if (question.type === "MCQ") {
+        const single = question.choice?.answers?.single;
+        const multiple = question.choice?.answers?.multiple;
+
+        if (single) {
+            return typeof answer === "string" && answer === single;
+        }
+
+        if (!Array.isArray(answer) || !multiple) {
+            return false;
+        }
+
+        const expected = [...multiple].sort();
+        const received = [...answer].sort();
+        return expected.length === received.length
+            && expected.every((value, index) => value === received[index]);
+    }
+
+    if (question.type === "TF") {
+        if (Array.isArray(answer)) {
+            return false;
+        }
+
+        const expected = normalizeText(question.choice?.answers?.single ?? "");
+        const received = normalizeText(answer);
+        return expected === received;
+    }
+
+    if (!question.frq || Array.isArray(answer)) {
+        return false;
+    }
+
+    if (question.frq.kind === "NUMBER") {
+        const parsed = Number(answer);
+        if (!Number.isFinite(parsed)) {
+            return false;
+        }
+
+        const tolerance = question.frq.tolerance ?? 0;
+        return (question.frq.accepted_numbers ?? []).some((target) => {
+            return Math.abs(target - parsed) <= tolerance;
+        });
+    }
+
+    const normalized = normalizeText(answer);
+    return (question.frq.accepted_texts ?? []).some((text) => normalizeText(text) === normalized);
+}
+
+export function sanitizeQuiz(topics: CmsTopic[], questions: CmsQuestion[]): DemoQuizPayload {
+    const topicMap = new Map(
+        topics.map((topic) => [topicIdOf(topic), topic.name])
+    );
+
+    const sanitizedQuestions = questions.map((question) => {
+        const topicIds = question.topic_ids.map(String);
+
+        return {
+            questionId: questionIdOf(question),
+            prompt: question.prompt,
+            difficulty: question.difficulty,
+            type: question.type,
+            answerMode: answerModeOf(question),
+            options: optionsOf(question),
+            topicIds,
+            topics: topicIds.map((topicId) => topicMap.get(topicId) ?? "Unassigned topic"),
+            hint: question.hint ?? "",
+            points: question.points ?? 100
+        } satisfies DemoQuestion;
+    });
+
+    const topicCounts = new Map<string, number>();
+    sanitizedQuestions.forEach((question) => {
+        question.topicIds.forEach((topicId) => {
+            topicCounts.set(topicId, (topicCounts.get(topicId) ?? 0) + 1);
+        });
+    });
+
+    return {
+        title: "Quiz",
+        subtitle: "",
+        topics: topics.map((topic) => ({
+            id: topicIdOf(topic),
+            name: topic.name,
+            questionCount: topicCounts.get(topicIdOf(topic)) ?? 0
+        })),
+        questions: sanitizedQuestions
+    };
+}
+
+export function evaluateAnswer(question: CmsQuestion, answer: string | string[]): CheckAnswerResult {
+    return {
+        correct: isCorrect(question, answer),
+        correctAnswer: formatCorrectAnswer(question),
+        explanation: question.explanation?.trim() || "This question does not have an explanation yet."
+    };
+}

--- a/demo/backend/src/seed.ts
+++ b/demo/backend/src/seed.ts
@@ -1,0 +1,369 @@
+import dotenv from "dotenv";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.join(__dirname, "../.env") });
+
+const baseUrl = (process.env.CMS_BASE_URL || "http://localhost:3000").replace(/\/+$/, "");
+const email = process.env.CMS_EMAIL;
+const password = process.env.CMS_PASSWORD;
+const fullName = process.env.CMS_FULL_NAME || "Demo User";
+
+if (!email || !password) {
+    console.error("CMS_EMAIL and CMS_PASSWORD must be set in .env");
+    process.exit(1);
+}
+
+type ApiResponse<T> = {
+    ok: boolean;
+    status: number;
+    message?: string;
+    body?: T;
+};
+
+async function api<T>(
+    path: string,
+    init: RequestInit,
+    token?: string
+): Promise<T> {
+    const headers = new Headers(init.headers);
+    headers.set("Content-Type", "application/json");
+
+    if (token) {
+        headers.set("Authorization", `Bearer ${token}`);
+    }
+
+    const response = await fetch(`${baseUrl}/api/${path}`, {
+        ...init,
+        headers
+    });
+
+    const json = await response.json() as ApiResponse<T>;
+
+    if (!json.ok) {
+        throw new Error(json.message || `Request failed: ${path}`);
+    }
+
+    return json.body as T;
+}
+
+async function register() {
+    console.log("Registering demo user...");
+    try {
+        await api("users/register", {
+            method: "POST",
+            body: JSON.stringify({
+                full_name: fullName,
+                email,
+                password
+            })
+        });
+        console.log("  User registered successfully");
+    } catch (error) {
+        if (error instanceof Error && error.message.includes("already")) {
+            console.log("  User already exists, skipping registration");
+        } else {
+            throw error;
+        }
+    }
+}
+
+async function login(): Promise<string> {
+    console.log("Logging in...");
+    const result = await api<{ token: string }>("users/login", {
+        method: "POST",
+        body: JSON.stringify({ email, password })
+    });
+    console.log("  Logged in successfully");
+    return result.token;
+}
+
+async function createTopic(
+    token: string,
+    name: string,
+    description: string
+): Promise<string> {
+    const result = await api<{ topic_id: string }>("topics/create", {
+        method: "POST",
+        body: JSON.stringify({ name, description })
+    }, token);
+    return result.topic_id;
+}
+
+type QuestionInput = {
+    topic_ids: string[];
+    prompt: string;
+    difficulty: "EASY" | "MEDIUM" | "HARD";
+    hint?: string;
+    explanation?: string;
+    points?: number;
+} & (
+    | { type: "MCQ"; choice: { options: string[]; answers: { single?: string; multiple?: string[] } } }
+    | { type: "TF"; choice: { answers: { single: "True" | "False" } } }
+    | { type: "FRQ"; frq: { kind: "NUMBER"; accepted_numbers: number[]; tolerance?: number } | { kind: "TEXT"; accepted_texts: string[] } }
+);
+
+async function createQuestion(token: string, question: QuestionInput): Promise<string> {
+    const result = await api<{ question_id: string }>("questions/create", {
+        method: "POST",
+        body: JSON.stringify(question)
+    }, token);
+    return result.question_id;
+}
+
+async function seed() {
+    console.log(`\nSeeding demo data to ${baseUrl}\n`);
+
+    await register();
+    const token = await login();
+
+    // Create topics
+    console.log("Creating topics...");
+    const topics: Record<string, string> = {};
+
+    const topicData = [
+        { name: "Mathematics", description: "Algebra, calculus, and numerical problems" },
+        { name: "Science", description: "Physics, chemistry, and biology" },
+        { name: "History", description: "World history and historical events" },
+        { name: "Programming", description: "Computer science and coding concepts" }
+    ];
+
+    for (const topic of topicData) {
+        const id = await createTopic(token, topic.name, topic.description);
+        topics[topic.name] = id;
+        console.log(`  Created topic: ${topic.name}`);
+    }
+
+    // Create questions
+    console.log("Creating questions...");
+
+    const questions: QuestionInput[] = [
+        // Mathematics
+        {
+            topic_ids: [topics["Mathematics"]],
+            type: "MCQ",
+            prompt: "What is the value of x in the equation 2x + 5 = 15?",
+            difficulty: "EASY",
+            hint: "Isolate x by subtracting 5 from both sides first.",
+            explanation: "2x + 5 = 15 → 2x = 10 → x = 5",
+            points: 100,
+            choice: {
+                options: ["3", "5", "7", "10"],
+                answers: { single: "5" }
+            }
+        },
+        {
+            topic_ids: [topics["Mathematics"]],
+            type: "FRQ",
+            prompt: "What is the square root of 144?",
+            difficulty: "EASY",
+            explanation: "√144 = 12 because 12 × 12 = 144",
+            points: 100,
+            frq: {
+                kind: "NUMBER",
+                accepted_numbers: [12],
+                tolerance: 0
+            }
+        },
+        {
+            topic_ids: [topics["Mathematics"]],
+            type: "MCQ",
+            prompt: "Which of the following are prime numbers?",
+            difficulty: "MEDIUM",
+            hint: "A prime number is only divisible by 1 and itself.",
+            explanation: "2, 3, 5, and 7 are prime. 4 = 2×2, 6 = 2×3, 9 = 3×3",
+            points: 150,
+            choice: {
+                options: ["2", "3", "4", "5", "6", "7", "9"],
+                answers: { multiple: ["2", "3", "5", "7"] }
+            }
+        },
+        {
+            topic_ids: [topics["Mathematics"]],
+            type: "FRQ",
+            prompt: "Calculate the derivative of f(x) = 3x² + 2x - 5 at x = 2",
+            difficulty: "HARD",
+            hint: "First find f'(x), then substitute x = 2.",
+            explanation: "f'(x) = 6x + 2. At x = 2: f'(2) = 6(2) + 2 = 14",
+            points: 200,
+            frq: {
+                kind: "NUMBER",
+                accepted_numbers: [14],
+                tolerance: 0
+            }
+        },
+
+        // Science
+        {
+            topic_ids: [topics["Science"]],
+            type: "MCQ",
+            prompt: "What is the chemical symbol for water?",
+            difficulty: "EASY",
+            explanation: "Water consists of 2 hydrogen atoms and 1 oxygen atom: H₂O",
+            points: 100,
+            choice: {
+                options: ["H2O", "CO2", "NaCl", "O2"],
+                answers: { single: "H2O" }
+            }
+        },
+        {
+            topic_ids: [topics["Science"]],
+            type: "TF",
+            prompt: "The speed of light in a vacuum is approximately 300,000 km/s.",
+            difficulty: "EASY",
+            explanation: "The speed of light is approximately 299,792 km/s, which rounds to 300,000 km/s.",
+            points: 100,
+            choice: {
+                answers: { single: "True" }
+            }
+        },
+        {
+            topic_ids: [topics["Science"]],
+            type: "MCQ",
+            prompt: "Which planet is known as the Red Planet?",
+            difficulty: "EASY",
+            hint: "It's named after the Roman god of war.",
+            explanation: "Mars appears red due to iron oxide (rust) on its surface.",
+            points: 100,
+            choice: {
+                options: ["Venus", "Mars", "Jupiter", "Saturn"],
+                answers: { single: "Mars" }
+            }
+        },
+        {
+            topic_ids: [topics["Science"]],
+            type: "FRQ",
+            prompt: "How many bones are in the adult human body?",
+            difficulty: "MEDIUM",
+            hint: "It's more than 200.",
+            explanation: "Adults have 206 bones. Babies are born with about 270, but many fuse together.",
+            points: 150,
+            frq: {
+                kind: "NUMBER",
+                accepted_numbers: [206],
+                tolerance: 0
+            }
+        },
+
+        // History
+        {
+            topic_ids: [topics["History"]],
+            type: "MCQ",
+            prompt: "In what year did World War II end?",
+            difficulty: "EASY",
+            explanation: "WWII ended in 1945 with the surrender of Japan on September 2nd.",
+            points: 100,
+            choice: {
+                options: ["1943", "1944", "1945", "1946"],
+                answers: { single: "1945" }
+            }
+        },
+        {
+            topic_ids: [topics["History"]],
+            type: "TF",
+            prompt: "The Great Wall of China is visible from space with the naked eye.",
+            difficulty: "MEDIUM",
+            explanation: "This is a common myth. The Great Wall is too narrow to be seen from space without aid.",
+            points: 150,
+            choice: {
+                answers: { single: "False" }
+            }
+        },
+        {
+            topic_ids: [topics["History"]],
+            type: "FRQ",
+            prompt: "Who was the first President of the United States?",
+            difficulty: "EASY",
+            explanation: "George Washington served as the first President from 1789 to 1797.",
+            points: 100,
+            frq: {
+                kind: "TEXT",
+                accepted_texts: ["George Washington", "Washington", "george washington", "washington"]
+            }
+        },
+
+        // Programming
+        {
+            topic_ids: [topics["Programming"]],
+            type: "MCQ",
+            prompt: "Which of the following is NOT a programming language?",
+            difficulty: "EASY",
+            explanation: "HTML is a markup language, not a programming language.",
+            points: 100,
+            choice: {
+                options: ["Python", "JavaScript", "HTML", "Java"],
+                answers: { single: "HTML" }
+            }
+        },
+        {
+            topic_ids: [topics["Programming"]],
+            type: "TF",
+            prompt: "In most programming languages, array indices start at 0.",
+            difficulty: "EASY",
+            explanation: "Most languages like C, Java, Python, and JavaScript use 0-based indexing.",
+            points: 100,
+            choice: {
+                answers: { single: "True" }
+            }
+        },
+        {
+            topic_ids: [topics["Programming"]],
+            type: "MCQ",
+            prompt: "What does API stand for?",
+            difficulty: "EASY",
+            explanation: "API = Application Programming Interface",
+            points: 100,
+            choice: {
+                options: [
+                    "Application Programming Interface",
+                    "Advanced Program Integration",
+                    "Automated Process Implementation",
+                    "Application Process Integration"
+                ],
+                answers: { single: "Application Programming Interface" }
+            }
+        },
+        {
+            topic_ids: [topics["Programming"]],
+            type: "FRQ",
+            prompt: "What is the time complexity of binary search?",
+            difficulty: "MEDIUM",
+            hint: "Think about how many times you can divide n by 2.",
+            explanation: "Binary search has O(log n) time complexity because it halves the search space each iteration.",
+            points: 150,
+            frq: {
+                kind: "TEXT",
+                accepted_texts: ["O(log n)", "O(logn)", "log n", "logn", "O(log(n))", "logarithmic"]
+            }
+        },
+        {
+            topic_ids: [topics["Programming"]],
+            type: "MCQ",
+            prompt: "Which data structures use LIFO (Last In, First Out) ordering?",
+            difficulty: "MEDIUM",
+            explanation: "Stacks use LIFO ordering. Queues use FIFO (First In, First Out).",
+            points: 150,
+            choice: {
+                options: ["Stack", "Queue", "Array", "Linked List"],
+                answers: { single: "Stack" }
+            }
+        }
+    ];
+
+    for (const question of questions) {
+        await createQuestion(token, question);
+        console.log(`  Created: ${question.prompt.substring(0, 50)}...`);
+    }
+
+    console.log(`\nSeeding complete!`);
+    console.log(`  Topics: ${Object.keys(topics).length}`);
+    console.log(`  Questions: ${questions.length}`);
+}
+
+seed().catch((error) => {
+    console.error("\nSeeding failed:", error.message);
+    process.exit(1);
+});

--- a/demo/backend/src/types.ts
+++ b/demo/backend/src/types.ts
@@ -1,0 +1,72 @@
+export type CmsResponse<T> = {
+    ok: boolean;
+    status: number;
+    message?: string;
+    body?: T;
+};
+
+export type CmsTopic = {
+    _id: string;
+    name: string;
+    description?: string;
+};
+
+export type CmsQuestion = {
+    _id?: string;
+    question_id: string;
+    topic_ids: string[];
+    type: "MCQ" | "TF" | "FRQ";
+    prompt: string;
+    difficulty: "EASY" | "MEDIUM" | "HARD";
+    hint?: string;
+    explanation?: string;
+    points?: number;
+    choice?: {
+        options?: string[];
+        answers?: {
+            single?: string;
+            multiple?: string[];
+        };
+    };
+    frq?: {
+        kind: "NUMBER" | "TEXT";
+        accepted_numbers?: number[];
+        tolerance?: number;
+        accepted_texts?: string[];
+    };
+};
+
+export type DemoQuestion = {
+    questionId: string;
+    prompt: string;
+    difficulty: CmsQuestion["difficulty"];
+    type: CmsQuestion["type"];
+    answerMode: "single" | "multiple" | "number" | "text" | "boolean";
+    options: string[];
+    topicIds: string[];
+    topics: string[];
+    hint: string;
+    points: number;
+};
+
+export type DemoQuizPayload = {
+    title: string;
+    subtitle: string;
+    topics: Array<{
+        id: string;
+        name: string;
+        questionCount: number;
+    }>;
+    questions: DemoQuestion[];
+};
+
+export type CheckAnswerInput = {
+    questionId: string;
+    answer: string | string[];
+};
+
+export type CheckAnswerResult = {
+    correct: boolean;
+    correctAnswer: string;
+    explanation: string;
+};

--- a/demo/backend/tsconfig.json
+++ b/demo/backend/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/demo/frontend/index.html
+++ b/demo/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quiz</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/demo/frontend/package.json
+++ b/demo/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "educms-demo-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.2.2",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "tailwindcss": "^4.2.2",
+    "typescript": "~5.9.3",
+    "vite": "^8.0.3"
+  }
+}

--- a/demo/frontend/src/App.tsx
+++ b/demo/frontend/src/App.tsx
@@ -1,0 +1,386 @@
+import { useEffect, useState } from "react";
+import type { ApiEnvelope, CheckResponse, DemoQuestion, DemoQuiz } from "./types.ts";
+
+type SubmissionMap = Record<string, boolean>;
+
+const emptyQuiz: DemoQuiz = {
+    title: "Quiz",
+    subtitle: "",
+    topics: [],
+    questions: []
+};
+
+function difficultyLabel(value: DemoQuestion["difficulty"]) {
+    if (value === "EASY") return "Easy";
+    if (value === "MEDIUM") return "Medium";
+    return "Hard";
+}
+
+function difficultyColor(value: DemoQuestion["difficulty"]) {
+    if (value === "EASY") return "bg-green-500/20 text-green-400";
+    if (value === "MEDIUM") return "bg-yellow-500/20 text-yellow-400";
+    return "bg-red-500/20 text-red-400";
+}
+
+function toAnswerPayload(question: DemoQuestion, single: string, multiple: string[], text: string) {
+    if (question.answerMode === "multiple") {
+        return multiple;
+    }
+    return text || single;
+}
+
+export default function App() {
+    const [quiz, setQuiz] = useState<DemoQuiz>(emptyQuiz);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+    const [selectedTopicId, setSelectedTopicId] = useState("all");
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [singleAnswer, setSingleAnswer] = useState("");
+    const [multipleAnswer, setMultipleAnswer] = useState<string[]>([]);
+    const [textAnswer, setTextAnswer] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+    const [feedback, setFeedback] = useState<CheckResponse | null>(null);
+    const [submissions, setSubmissions] = useState<SubmissionMap>({});
+
+    useEffect(() => {
+        void loadQuiz();
+    }, []);
+
+    async function loadQuiz() {
+        setLoading(true);
+        setError("");
+
+        try {
+            const response = await fetch("/api/quiz");
+            const data = await response.json() as ApiEnvelope<DemoQuiz>;
+
+            if (!data.ok || !data.body) {
+                throw new Error(data.message || "Unable to load quiz data");
+            }
+
+            setQuiz(data.body);
+        } catch (loadError) {
+            setError(loadError instanceof Error ? loadError.message : String(loadError));
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    const filteredQuestions = selectedTopicId === "all"
+        ? quiz.questions
+        : quiz.questions.filter((question) => question.topicIds.includes(selectedTopicId));
+
+    const currentQuestion = filteredQuestions[currentIndex] ?? null;
+    const answeredCount = Object.keys(submissions).length;
+    const correctCount = Object.values(submissions).filter(Boolean).length;
+
+    useEffect(() => {
+        setCurrentIndex(0);
+        resetComposer();
+    }, [selectedTopicId]);
+
+    function resetComposer() {
+        setSingleAnswer("");
+        setMultipleAnswer([]);
+        setTextAnswer("");
+        setFeedback(null);
+    }
+
+    function goToQuestion(index: number) {
+        setCurrentIndex(index);
+        resetComposer();
+    }
+
+    function toggleMultiOption(option: string) {
+        setMultipleAnswer((current) => {
+            return current.includes(option)
+                ? current.filter((value) => value !== option)
+                : [...current, option];
+        });
+    }
+
+    async function submitAnswer() {
+        if (!currentQuestion) {
+            return;
+        }
+
+        setSubmitting(true);
+        setFeedback(null);
+
+        try {
+            const response = await fetch("/api/check", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    questionId: currentQuestion.questionId,
+                    answer: toAnswerPayload(currentQuestion, singleAnswer, multipleAnswer, textAnswer)
+                })
+            });
+
+            const data = await response.json() as ApiEnvelope<CheckResponse>;
+
+            if (!data.ok || !data.body) {
+                throw new Error(data.message || "Unable to check answer");
+            }
+
+            setFeedback(data.body);
+            setSubmissions((current) => ({
+                ...current,
+                [currentQuestion.questionId]: data.body!.correct
+            }));
+        } catch (submitError) {
+            setError(submitError instanceof Error ? submitError.message : String(submitError));
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    const canSubmit = (() => {
+        if (!currentQuestion) {
+            return false;
+        }
+
+        if (currentQuestion.answerMode === "multiple") {
+            return multipleAnswer.length > 0;
+        }
+
+        if (currentQuestion.answerMode === "number" || currentQuestion.answerMode === "text") {
+            return textAnswer.trim().length > 0;
+        }
+
+        return singleAnswer.length > 0;
+    })();
+
+    if (loading) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <p className="text-zinc-400 text-lg">Loading quiz...</p>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="min-h-screen flex items-center justify-center">
+                <div className="text-center">
+                    <p className="text-red-400 text-lg mb-4">{error}</p>
+                    <button
+                        type="button"
+                        className="px-4 py-2 bg-zinc-700 hover:bg-zinc-600 text-white rounded-lg transition"
+                        onClick={() => void loadQuiz()}
+                    >
+                        Try Again
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="min-h-screen p-4 md:p-8">
+            <div className="max-w-6xl mx-auto">
+                <header className="mb-8">
+                    <h1 className="text-2xl md:text-3xl font-bold text-white mb-2">{quiz.title}</h1>
+                    {quiz.subtitle && <p className="text-zinc-400">{quiz.subtitle}</p>}
+                    <div className="flex gap-4 mt-4 text-sm">
+                        <span className="text-zinc-400">
+                            <span className="text-white font-medium">{quiz.questions.length}</span> questions
+                        </span>
+                        <span className="text-zinc-400">
+                            <span className="text-white font-medium">{answeredCount}</span> answered
+                        </span>
+                        <span className="text-zinc-400">
+                            <span className="text-green-400 font-medium">{correctCount}</span> correct
+                        </span>
+                    </div>
+                </header>
+
+                <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-6">
+                    <main>
+                        {!currentQuestion ? (
+                            <div className="bg-zinc-800 rounded-xl p-8 text-center">
+                                <p className="text-zinc-400">No questions available for this topic.</p>
+                            </div>
+                        ) : (
+                            <div className="bg-zinc-800 rounded-xl p-6">
+                                <div className="flex flex-wrap items-center gap-2 mb-4">
+                                    <span className="text-sm text-zinc-400">
+                                        Question {currentIndex + 1} of {filteredQuestions.length}
+                                    </span>
+                                    <span className={`text-xs px-2 py-1 rounded-full ${difficultyColor(currentQuestion.difficulty)}`}>
+                                        {difficultyLabel(currentQuestion.difficulty)}
+                                    </span>
+                                    <span className="text-xs px-2 py-1 rounded-full bg-zinc-700 text-zinc-300">
+                                        {currentQuestion.points} pts
+                                    </span>
+                                    {currentQuestion.topics.map((topic) => (
+                                        <span key={topic} className="text-xs px-2 py-1 rounded-full bg-zinc-700 text-zinc-300">
+                                            {topic}
+                                        </span>
+                                    ))}
+                                </div>
+
+                                <h2 className="text-xl md:text-2xl font-semibold text-white mb-6">
+                                    {currentQuestion.prompt}
+                                </h2>
+
+                                <div className="space-y-3 mb-6">
+                                    {(currentQuestion.answerMode === "single" || currentQuestion.answerMode === "boolean") && (
+                                        currentQuestion.options.map((option) => (
+                                            <label
+                                                key={option}
+                                                className={`flex items-center gap-3 p-4 rounded-lg border cursor-pointer transition ${
+                                                    singleAnswer === option
+                                                        ? "border-indigo-500 bg-indigo-500/10"
+                                                        : "border-zinc-700 bg-zinc-900 hover:border-zinc-600"
+                                                }`}
+                                            >
+                                                <input
+                                                    type="radio"
+                                                    name="single-answer"
+                                                    value={option}
+                                                    checked={singleAnswer === option}
+                                                    onChange={(event) => setSingleAnswer(event.target.value)}
+                                                    className="w-4 h-4 text-indigo-500"
+                                                />
+                                                <span className="text-white">{option}</span>
+                                            </label>
+                                        ))
+                                    )}
+
+                                    {currentQuestion.answerMode === "multiple" && (
+                                        currentQuestion.options.map((option) => {
+                                            const checked = multipleAnswer.includes(option);
+                                            return (
+                                                <label
+                                                    key={option}
+                                                    className={`flex items-center gap-3 p-4 rounded-lg border cursor-pointer transition ${
+                                                        checked
+                                                            ? "border-indigo-500 bg-indigo-500/10"
+                                                            : "border-zinc-700 bg-zinc-900 hover:border-zinc-600"
+                                                    }`}
+                                                >
+                                                    <input
+                                                        type="checkbox"
+                                                        value={option}
+                                                        checked={checked}
+                                                        onChange={() => toggleMultiOption(option)}
+                                                        className="w-4 h-4 text-indigo-500"
+                                                    />
+                                                    <span className="text-white">{option}</span>
+                                                </label>
+                                            );
+                                        })
+                                    )}
+
+                                    {(currentQuestion.answerMode === "text" || currentQuestion.answerMode === "number") && (
+                                        <input
+                                            type={currentQuestion.answerMode === "number" ? "number" : "text"}
+                                            className="w-full bg-zinc-900 border border-zinc-700 rounded-lg px-4 py-3 text-white placeholder-zinc-500 focus:outline-none focus:border-indigo-500"
+                                            placeholder={currentQuestion.answerMode === "number" ? "Enter a number" : "Type your answer"}
+                                            value={textAnswer}
+                                            onChange={(event) => setTextAnswer(event.target.value)}
+                                        />
+                                    )}
+                                </div>
+
+                                {currentQuestion.hint && (
+                                    <div className="bg-teal-900/30 border border-teal-700/50 rounded-lg p-4 mb-6">
+                                        <p className="text-sm text-teal-400 font-medium mb-1">Hint</p>
+                                        <p className="text-zinc-300">{currentQuestion.hint}</p>
+                                    </div>
+                                )}
+
+                                <div className="flex flex-wrap gap-3">
+                                    <button
+                                        type="button"
+                                        className="px-6 py-2.5 bg-indigo-600 hover:bg-indigo-500 disabled:bg-zinc-700 disabled:cursor-not-allowed text-white font-medium rounded-lg transition"
+                                        disabled={!canSubmit || submitting}
+                                        onClick={() => void submitAnswer()}
+                                    >
+                                        {submitting ? "Checking..." : "Submit"}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className="px-6 py-2.5 bg-zinc-700 hover:bg-zinc-600 disabled:bg-zinc-800 disabled:cursor-not-allowed text-white font-medium rounded-lg transition"
+                                        disabled={currentIndex >= filteredQuestions.length - 1}
+                                        onClick={() => goToQuestion(currentIndex + 1)}
+                                    >
+                                        Next
+                                    </button>
+                                </div>
+
+                                {feedback && (
+                                    <div className={`mt-6 p-4 rounded-lg border ${
+                                        feedback.correct
+                                            ? "bg-green-900/30 border-green-700/50"
+                                            : "bg-red-900/30 border-red-700/50"
+                                    }`}>
+                                        <p className={`font-semibold mb-2 ${feedback.correct ? "text-green-400" : "text-red-400"}`}>
+                                            {feedback.correct ? "Correct!" : "Incorrect"}
+                                        </p>
+                                        <p className="text-zinc-300 text-sm mb-1">
+                                            <span className="text-zinc-400">Answer:</span> {feedback.correctAnswer}
+                                        </p>
+                                        <p className="text-zinc-300 text-sm">{feedback.explanation}</p>
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                    </main>
+
+                    <aside className="space-y-4 order-1 lg:order-2">
+                        <div className="bg-zinc-800 rounded-xl p-4">
+                            <label className="block text-sm text-zinc-400 mb-2" htmlFor="topic-filter">
+                                Filter by topic
+                            </label>
+                            <select
+                                id="topic-filter"
+                                className="w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-white"
+                                value={selectedTopicId}
+                                onChange={(event) => setSelectedTopicId(event.target.value)}
+                            >
+                                <option value="all">All topics</option>
+                                {quiz.topics.map((topic) => (
+                                    <option key={topic.id} value={topic.id}>
+                                        {topic.name} ({topic.questionCount})
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+
+                        <div className="bg-zinc-800 rounded-xl p-4">
+                            <p className="text-sm text-zinc-400 mb-3">Questions</p>
+                            <div className="flex flex-col gap-2 max-h-80 overflow-y-auto">
+                                {filteredQuestions.map((question, index) => {
+                                    const state = submissions[question.questionId];
+                                    let bgClass = "bg-zinc-700 hover:bg-zinc-600";
+                                    if (index === currentIndex) {
+                                        bgClass = "bg-indigo-600 hover:bg-indigo-500";
+                                    } else if (state === true) {
+                                        bgClass = "bg-green-600/30 hover:bg-green-600/40";
+                                    } else if (state === false) {
+                                        bgClass = "bg-red-600/30 hover:bg-red-600/40";
+                                    }
+
+                                    return (
+                                        <button
+                                            key={question.questionId}
+                                            type="button"
+                                            className={`${bgClass} text-white text-sm font-medium rounded-lg px-3 py-2 text-left transition`}
+                                            onClick={() => goToQuestion(index)}
+                                        >
+                                            {index + 1}. {question.prompt.length > 30 ? question.prompt.slice(0, 30) + "..." : question.prompt}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    </aside>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/demo/frontend/src/main.tsx
+++ b/demo/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App.tsx";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+        <App />
+    </StrictMode>
+);

--- a/demo/frontend/src/styles.css
+++ b/demo/frontend/src/styles.css
@@ -1,0 +1,5 @@
+@import "tailwindcss";
+
+body {
+    background-color: #18181b;
+}

--- a/demo/frontend/src/types.ts
+++ b/demo/frontend/src/types.ts
@@ -1,0 +1,35 @@
+export type DemoQuestion = {
+    questionId: string;
+    prompt: string;
+    difficulty: "EASY" | "MEDIUM" | "HARD";
+    type: "MCQ" | "TF" | "FRQ";
+    answerMode: "single" | "multiple" | "number" | "text" | "boolean";
+    options: string[];
+    topicIds: string[];
+    topics: string[];
+    hint: string;
+    points: number;
+};
+
+export type DemoQuiz = {
+    title: string;
+    subtitle: string;
+    topics: Array<{
+        id: string;
+        name: string;
+        questionCount: number;
+    }>;
+    questions: DemoQuestion[];
+};
+
+export type ApiEnvelope<T> = {
+    ok: boolean;
+    message?: string;
+    body?: T;
+};
+
+export type CheckResponse = {
+    correct: boolean;
+    correctAnswer: string;
+    explanation: string;
+};

--- a/demo/frontend/tsconfig.app.json
+++ b/demo/frontend/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/demo/frontend/tsconfig.json
+++ b/demo/frontend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/demo/frontend/tsconfig.node.json
+++ b/demo/frontend/tsconfig.node.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/demo/frontend/vite.config.ts
+++ b/demo/frontend/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+    plugins: [react(), tailwindcss()],
+    server: {
+        port: 4173,
+        proxy: {
+            "/api": "http://localhost:3001"
+        }
+    }
+});


### PR DESCRIPTION
This PR adds a demo quiz app in /demo that uses a teacher CMS account to populate a quiz with that teacher’s questions. The demo is intended to showcase core quiz functionality, including:
- topics
- multiple question types
- difficulty levels
- hints
- explanations
- correct answers

<img width="1512" height="982" alt="Screenshot 2026-04-03 at 11 30 31 AM" src="https://github.com/user-attachments/assets/0accab63-2a32-4f3a-b487-39b1376d50f3" />
<img width="1512" height="982" alt="Screenshot 2026-04-03 at 11 30 49 AM" src="https://github.com/user-attachments/assets/3df09749-1897-4508-877b-2278300abcdb" />
<img width="1512" height="982" alt="Screenshot 2026-04-03 at 11 31 11 AM" src="https://github.com/user-attachments/assets/406eab68-19e4-4445-b595-9c2205f0cf9f" />


It also includes a seed script to populate the CMS with a demo teacher account and demo questions:
```
npm run seed
```

The `/demo` app mirrors the structure of the main app, with separate `/backend` and `/frontend` directories. The backend uses Express, the frontend uses Vite, and the UI styling is meant to stay visually consistent with the CMS.

## Important note

I did not include Docker or deployment config changes.
One possible approach would be to:
- add the demo build step to the Docker build file
- include it as a service in docker-compose file
- reverse proxy it to the demo subdomain

I could also host it separately on a different domain if that ends up being simpler.